### PR TITLE
Fix direction-related bug

### DIFF
--- a/challenges/CC_03_Snake_game_p5.js/snake.js
+++ b/challenges/CC_03_Snake_game_p5.js/snake.js
@@ -22,8 +22,12 @@ function Snake() {
   }
 
   this.dir = function(x, y) {
-    this.xspeed = x;
-    this.yspeed = y;
+    if(this.xspeed != -1*x) {
+      this.xspeed = x;
+    }
+    if(this.yspeed != -1*y) {
+      this.yspeed = y;
+    }
   }
 
   this.death = function() {


### PR DESCRIPTION
Currently, if snake is moving left, right arrow will instantly kill and end the game, while it should not.  Added check to prevent it.